### PR TITLE
Feature/super cache backends and engines support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ sdist/
 .coverage
 docs/_*/
 .tox/
+*.swp

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 What’s new in django-cachalot?
 ==============================
 
+1.4.2
+-----
+
+- Hard-coded class path comparisons for compatibility in django app checks only yield warnings, since there's not
+  a good way to maintain current performance and support super cache backend types
+
 1.4.1
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -3,21 +3,21 @@ Django-cachalot
 
 Caches your Django ORM queries and automatically invalidates them.
 
-.. image:: https://raw.github.com/BertrandBordage/django-cachalot/master/django-cachalot.jpg
+.. image:: https://raw.github.com/ambitioninc/django-cachalot/master/django-cachalot.jpg
 
 ----
 
 .. image:: http://img.shields.io/pypi/v/django-cachalot.svg?style=flat-square&maxAge=3600
    :target: https://pypi.python.org/pypi/django-cachalot
 
-.. image:: http://img.shields.io/travis/BertrandBordage/django-cachalot/master.svg?style=flat-square&maxAge=3600
-   :target: https://travis-ci.org/BertrandBordage/django-cachalot
+.. image:: http://img.shields.io/travis/ambitioninc/django-cachalot/master.svg?style=flat-square&maxAge=3600
+   :target: https://travis-ci.org/ambitioninc/django-cachalot
 
-.. image:: http://img.shields.io/coveralls/BertrandBordage/django-cachalot/master.svg?style=flat-square&maxAge=3600
-   :target: https://coveralls.io/r/BertrandBordage/django-cachalot?branch=master
+.. image:: http://img.shields.io/coveralls/ambitioninc/django-cachalot/master.svg?style=flat-square&maxAge=3600
+   :target: https://coveralls.io/r/ambitioninc/django-cachalot?branch=master
 
-.. image:: http://img.shields.io/scrutinizer/g/BertrandBordage/django-cachalot/master.svg?style=flat-square&maxAge=3600
-   :target: https://scrutinizer-ci.com/g/BertrandBordage/django-cachalot/
+.. image:: http://img.shields.io/scrutinizer/g/ambitioninc/django-cachalot/master.svg?style=flat-square&maxAge=3600
+   :target: https://scrutinizer-ci.com/g/ambitioninc/django-cachalot/
 
 .. image:: https://img.shields.io/gitter/room/django-cachalot/Lobby.svg?style=flat-square&maxAge=3600
    :target: https://gitter.im/django-cachalot/Lobby

--- a/cachalot/__init__.py
+++ b/cachalot/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 4, 1)
+VERSION = (1, 4, 2)
 __version__ = '.'.join(map(str, VERSION))
 
 default_app_config = 'cachalot.apps.CachalotConfig'

--- a/cachalot/apps.py
+++ b/cachalot/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 from django.conf import settings
-from django.core.checks import register, Tags, Error
+from django.core.checks import register, Tags, Error, Warning
 
 from .monkey_patch import patch
 from .settings import cachalot_settings
@@ -49,7 +49,7 @@ def check_compatibility(app_configs, **kwargs):
             value = config[k]
             if value not in valid_values:
                 errors.append(
-                    Error(
+                    Warning(
                         '`%s` is not compatible with django-cachalot.' % value,
                         id='cachalot.E001',
                     )

--- a/publish.py
+++ b/publish.py
@@ -1,0 +1,5 @@
+import subprocess
+
+subprocess.call(['pip', 'install', 'wheel'])
+subprocess.call(['python', 'setup.py', 'clean', '--all'])
+subprocess.call(['python', 'setup.py', 'register', 'sdist', 'bdist_wheel', 'upload'])

--- a/settings.py
+++ b/settings.py
@@ -135,7 +135,7 @@ CACHALOT_ENABLED = True
 #
 
 # We put django-debug-toolbar before to reproduce the conditions of this issue:
-# https://github.com/BertrandBordage/django-cachalot/issues/62
+# https://github.com/ambitioninc/django-cachalot/issues/62
 INSTALLED_APPS = [
     'debug_toolbar',
 ] + INSTALLED_APPS + ['django.contrib.staticfiles']

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ with open(os.path.join(CURRENT_PATH, 'requirements.txt')) as f:
 
 
 setup(
-    name='django-cachalot',
+    name='ambition-django-cachalot',
     version=__version__,
     author='Bertrand Bordage',
     author_email='bordage.bertrand@gmail.com',
-    url='https://github.com/BertrandBordage/django-cachalot',
+    url='https://github.com/ambitioninc/django-cachalot',
     description='Caches your Django ORM queries '
                 'and automatically invalidates them.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
@jaredlewis I added a custom backend to our development env to log cache hits/misses, but this module only compares the configured engine/backend to a hard-coded list of class paths when determining compatibility, rather than checking to see if the configured class is a subclass of any of those listed.

In order to maintain current performance _and_ not have this hold up progress, I'm just making this raise a warning instead of an error.